### PR TITLE
Fix landing page layout columns to rows

### DIFF
--- a/app/layout.js
+++ b/app/layout.js
@@ -82,7 +82,7 @@ export default function RootLayout({ children }) {
           </Suspense>
           <AOSInitializer />
           <ConditionalNavBar />
-          <main className="flex-1 overflow-y-auto pt-10 md:pt-12 flex flex-col min-h-0">
+          <main className="flex-1 overflow-y-auto pt-10 md:pt-12 min-h-0">
             <MasterDatasetInitializer />
             <ConditionalWrapper>
               {children}

--- a/components/ConditionalWrapper.js
+++ b/components/ConditionalWrapper.js
@@ -12,7 +12,7 @@ export default function ConditionalWrapper({ children }) {
     <>
       {isLandingPage ? (
         // Landing page: render children without container wrapper
-        <div className="flex-1 flex min-h-0">
+        <div className="flex-1 min-h-0">
           {children}
         </div>
       ) : (

--- a/components/LandingPage/hero.jsx
+++ b/components/LandingPage/hero.jsx
@@ -88,8 +88,8 @@ export default function Hero() {
         <div className="pt-20 pb-32 md:pt-32 md:pb-72">
           <div className="grid grid-cols-1 lg:grid-cols-2 gap-8 lg:gap-6 items-center">
             
-              {/* Left side - Text content */}
-              <div className="text-center px-4 md:px-0 pt-10 lg:text-left lg:pr-24 relative z-50">
+            {/* Left side - Text content */}
+            <div className="text-center px-4 md:px-0 pt-10 lg:text-left lg:pr-24 relative z-50">
               <h1 className="text-5xl md:text-6xl font-extrabold leading-tighter tracking-tighter mb-10 text-pb_darkgray" data-aos="zoom-y-out">
                 Make league winning decisions <span className="bg-clip-text text-transparent bg-gradient-to-r from-pb_blue to-pb_green">faster.</span>
               </h1>


### PR DESCRIPTION
Correct landing page layout by removing conflicting flex column styles.

The main layout in `app/layout.js` and the `ConditionalWrapper` component were applying `flex flex-col` classes, which overrode the intended grid layouts in components like Hero and FeaturesBlocks, causing content to display in columns instead of rows.

---

[Open in Web](https://cursor.com/agents?id=bc-f6214e4d-9eab-403d-bc1e-8653d0dc1e61) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-f6214e4d-9eab-403d-bc1e-8653d0dc1e61) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)